### PR TITLE
Removed html tags from headings

### DIFF
--- a/30_Using_SOFA/30_Optional_Features/60_Haptics/10_SofaCarving.md
+++ b/30_Using_SOFA/30_Optional_Features/60_Haptics/10_SofaCarving.md
@@ -2,13 +2,13 @@ The SofaCarving plugin provides basic functionality for removing
 tetrahedra from a mesh. This can be used to simulate tissue destruction
 in medical simulations. []()
 
- class="mw-headline">Loading the Plugin
+Loading the Plugin
 ---------------------------------------------------
 
 To load the SofaCarving plugin, select **SOFA-PLUGIN\_SOFACARVING** in
 your Cmake configuration. Reconfigure, generate and build. []()
 
- class="mw-headline">CarvingManager
+CarvingManager
 -----------------------------------------------
 
 The plugin provides one component, the CarvingManager. When added to a


### PR DESCRIPTION
There were html tags next to the headings of the SOFA Carving Plugin documentation page