### PR TITLE
Add a tip to pinpoint CMake error when compiling for Windows.

### DIFF
--- a/10_Getting_Started/20_Build/30_Windows.md
+++ b/10_Getting_Started/20_Build/30_Windows.md
@@ -107,6 +107,12 @@ You need to **run Configure twice**, since SOFA requires two passes to
 manage the module dependencies. You can then customize your version of
 SOFA, activate or deactivate plugins and functionalities.
 
+If you have some errors, make absolutely sure all of your dependencies and your
+compilator are targeting the same architecture. For example, if you are not sure
+that the compiler is correctly set, do not hesitate to select it manually in the
+cmake-gui configuration screen instead of keeping the default ("Use default native
+compilers").
+
 When you are ready, press **Generate**. This will create your Visual
 Studio solution or your makefiles if you chose another generator.
 


### PR DESCRIPTION
Hello everyone.

I've compiled SOFA in the last two days and I went through some difficulties, including compiler and dependencies architecture mismatch. I think a little paragraph as a little tip could help some people.

I don't know if this is too specific to add to the doc, but I make this pull request in case it could be useful.