### PR TITLE
ADD eigen as an official dependency

### DIFF
--- a/10_Getting_Started/20_Build/10_Linux.md
+++ b/10_Getting_Started/20_Build/10_Linux.md
@@ -98,6 +98,11 @@ Finally, SOFA requires some libraries:
     ```bash
     sudo apt-get install libboost-atomic-dev libboost-chrono-dev libboost-date-time-dev libboost-filesystem-dev libboost-locale-dev libboost-regex-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev
     ```
+-   **Eigen** (>= 3.3.4)
+
+    ```bash
+    sudo apt install libeigen3-dev
+    ```
     
 -   **Python 2.7**
 

--- a/10_Getting_Started/20_Build/20_Mac_OS_X.md
+++ b/10_Getting_Started/20_Build/20_Mac_OS_X.md
@@ -57,6 +57,12 @@ To compile SOFA, you need to install several dependencies using Homebrew
     brew install boost
     ```
 
+-   **Eigen** (>= 3.3.4)
+    
+    ```bash
+    brew install eigen
+    ```
+
 -   **Additional libraries**: libPNG, libTIFF, libJPEG, Zlib, Glew
 
     ```bash

--- a/10_Getting_Started/20_Build/30_Windows.md
+++ b/10_Getting_Started/20_Build/30_Windows.md
@@ -43,6 +43,10 @@ Finally, SOFA requires some specific dependencies:
     [here](https://sourceforge.net/projects/boost/files/boost-binaries/).
     Beware of the correspondance between Visual Studio and MSVC versions (VS-2015 == MSVC-14.0, VS-2017 == MSVC-14.1).
 
+-   **Eigen** (>= 3.3.4)
+    Download the latest Eigen release [here](http://eigen.tuxfamily.org).
+    Unzip in the location of your choice, preferrably at `C:\` or `C:\Program files` for better discoverability by CMake find-modules (remember to extract the inner folder and rename it to `Eigen3` or `Eigen`).
+
 -   **Python 2.7**  
     Get Python 2.7.x (32 or 64 bit) on [python.org download page](https://www.python.org/downloads/windows/).
 


### PR DESCRIPTION
Since the PR [# 1281](https://github.com/sofa-framework/sofa/pull/1281), eigen will be an official dependency of SOFA instead of automatically pulling and building it.

Adding the 3.3.4 as minimal version + instructions.