### PR TITLE
Fix merge of folders with similar names

### DIFF
--- a/script/merge_docs.py
+++ b/script/merge_docs.py
@@ -102,8 +102,16 @@ def copy_subfolder(source_dir, source_subfolder, dest_dir, dest_subfolder):
         if os.path.isdir(source_item_path):
 
             existing_dest_item = item
+            
             for dest_item in os.listdir(dest_path):
-                if dest_item.endswith(item):
+
+                compare_dest_item = dest_item
+                underscore_index = compare_dest_item.find('_')
+
+                if underscore_index != -1:
+                    compare_dest_item = compare_dest_item[underscore_index + 1:]
+
+                if compare_dest_item == item:
                     existing_dest_item = dest_item
                     break
 


### PR DESCRIPTION
Folders like : 
- `Elastic` and `HyperElastic`
- `Linear` and `NonLinear`

were having issues at the merge when check if the names were ending the same way.
Now we remove (if present) the prefix (e.g>`10_` from `10_FEM`) and check if the string is **exactly** matching