### PR TITLE
Trigger doc weekly using cron

### DIFF
--- a/.github/workflows/trigger-doc.yml
+++ b/.github/workflows/trigger-doc.yml
@@ -2,6 +2,8 @@ name: Trigger DocGenerateAndPublish Workflow
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday morning
   push:
     branches:
       - master


### PR DESCRIPTION
As discussed on SOFA dev meeting, the documentation should now be updated every Monday.