### PR TITLE
fix typo CMakeList.txt to CMakeLists.txt

### DIFF
--- a/35_Plugins/20_Build_a_plugin_from_sources.md
+++ b/35_Plugins/20_Build_a_plugin_from_sources.md
@@ -32,10 +32,10 @@ In this directory, the structure is:
     - ...
 
 
-#### CMakeList of the repository
+#### CMakeLists.txt of the repository
 
 In order to handle this repository as one single set of external plugins,
-you need to write a short CMakeList.txt file as follows:
+you need to write a short CMakeLists.txt file as follows:
 
 ```
 cmake_minimum_required(VERSION 3.22)


### PR DESCRIPTION
In [Build a Plugin from Sources](https://sofa-framework.github.io/doc/plugins/build-a-plugin-from-sources/).

Corrected the typo from CMakeList.txt to CMakeLists.txt.