### PR TITLE
Add headers for auto generated plugin list

### DIFF
--- a/10_Getting_Started/20_Build/10_Linux.md
+++ b/10_Getting_Started/20_Build/10_Linux.md
@@ -232,7 +232,7 @@ git clone -b master https://github.com/sofa-framework/sofa.git sofa/src
    - activate or deactivate functionalities: see SOFA_XXX variables
 
    /// note | What is there to activate ?
-   [Here](../activate-plugins/) is an exaustive list of what plugin can be activated for an in-tree compilation.
+   [Here](../activate-plugins/) is an exhaustive list of plugins that can be activated for an in-tree compilation.
    ///
    
    Do not forget to **Configure** again to check if your changes are valid.

--- a/10_Getting_Started/20_Build/10_Linux.md
+++ b/10_Getting_Started/20_Build/10_Linux.md
@@ -230,10 +230,16 @@ git clone -b master https://github.com/sofa-framework/sofa.git sofa/src
    - choose the build type by setting CMAKE_BUILD_TYPE to "Release" or "RelWithDebInfo" (recommended) or "Debug"   
    - activate or deactivate plugins: see PLUGIN_XXX variables
    - activate or deactivate functionalities: see SOFA_XXX variables
+
+   /// note | What is there to activate ?
+   [Here](../activate-plugins/) is an exaustive list of what plugin can be activated for an in-tree compilation.
+   ///
    
    Do not forget to **Configure** again to check if your changes are valid.
 
 9. When you are ready, run **Generate**.
+
+
 
 
 

--- a/10_Getting_Started/20_Build/20_MacOS.md
+++ b/10_Getting_Started/20_Build/20_MacOS.md
@@ -195,6 +195,12 @@ git clone -b master https://github.com/sofa-framework/sofa.git sofa/src
    
    Do not forget to **Configure** again to check if your changes are valid.
 
+   /// note | What is there to activate ?
+   [Here](../activate-plugins/) is an exaustive list of what plugin can be activated for an in-tree compilation.
+   ///
+
+
+
 7. When you are ready, run **Generate**.
 
 

--- a/10_Getting_Started/20_Build/20_MacOS.md
+++ b/10_Getting_Started/20_Build/20_MacOS.md
@@ -196,7 +196,7 @@ git clone -b master https://github.com/sofa-framework/sofa.git sofa/src
    Do not forget to **Configure** again to check if your changes are valid.
 
    /// note | What is there to activate ?
-   [Here](../activate-plugins/) is an exaustive list of what plugin can be activated for an in-tree compilation.
+   [Here](../activate-plugins/) is an exhaustive list of plugins that can be activated for an in-tree compilation.
    ///
 
 

--- a/10_Getting_Started/20_Build/30_Windows.md
+++ b/10_Getting_Started/20_Build/30_Windows.md
@@ -156,6 +156,10 @@ git clone -b master https://github.com/sofa-framework/sofa.git sofa/src
 
    Do not forget to **Configure** again to check if your changes are valid.
 
+   /// note | What is there to activate ?
+   [Here](../activate-plugins/) is an exaustive list of what plugin can be activated for an in-tree compilation.
+   ///
+
 9. When you are ready, run **Generate**. In the build directory, this will create a Visual Studio project (.sln) or a Makefile depending on the generator you chose at step 4.
 
 

--- a/10_Getting_Started/20_Build/30_Windows.md
+++ b/10_Getting_Started/20_Build/30_Windows.md
@@ -157,7 +157,7 @@ git clone -b master https://github.com/sofa-framework/sofa.git sofa/src
    Do not forget to **Configure** again to check if your changes are valid.
 
    /// note | What is there to activate ?
-   [Here](../activate-plugins/) is an exaustive list of what plugin can be activated for an in-tree compilation.
+   [Here](../activate-plugins/) is an exhaustive list of plugins that can be activated for an in-tree compilation.
    ///
 
 9. When you are ready, run **Generate**. In the build directory, this will create a Visual Studio project (.sln) or a Makefile depending on the generator you chose at step 4.

--- a/10_Getting_Started/20_Build/50_Activate_Plugins.md
+++ b/10_Getting_Started/20_Build/50_Activate_Plugins.md
@@ -1,0 +1,17 @@
+# Activable plugins for in-tree compilation
+
+Multiple extensions can be activated when building the project. They are differentiated in three categories:
+1. Applications: extension that offers a new feature outside the SOFA API (e.g. a main for launching SOFA)
+2. Plugins: extension that enriches the SOFA API by adding new components or providing more support for external libraries (e.g. new constitutive laws, Qt gui)
+3. Directories: extension that contains multiple CMake projects that cannot be described by one of the above type
+Moreover those project are either directly present in the SOFA sources or need to be fetched because they have their own repository
+
+This page only purpose is to summarize those extensions in tables containing 
+- The name + hyperlink to the extension sources either in the SOFA repo or in its own repo
+- A quick description of what it is
+- Activation directives. 
+
+The activations directives propose two ways of activating those plugins in the build tree:
+1. Through custom CMake flags that [can be added during the cmake call](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-D). All of those plugins can be activated with one or two CMake flags named using their type and name. For example, the plugin SofaPython3 can be activated by activating both flags `SOFA_FETCH_SOFAPYTHON3=ON` and `PLUGIN_SOFAPYTHON3=ON` (because its sources are in a separate repository). If points are present in the name, they are replaced by "_" in the flag.
+2. Through preset that can be [specified during the cmake call](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#introduction)
+

--- a/10_Getting_Started/20_Build/50_Activate_Plugins.md
+++ b/10_Getting_Started/20_Build/50_Activate_Plugins.md
@@ -1,17 +1,17 @@
 # Activable plugins for in-tree compilation
 
-Multiple extensions can be activated when building the project. They are differentiated in three categories:
+Multiple extensions can be activated when building the project. They fall into three categories:
 1. Applications: extension that offers a new feature outside the SOFA API (e.g. a main for launching SOFA)
-2. Plugins: extension that enriches the SOFA API by adding new components or providing more support for external libraries (e.g. new constitutive laws, Qt gui)
+2. Plugins: extension that enriches the SOFA API by adding new components or providing more support for external libraries (e.g. new constitutive laws, alternative GUIs)
 3. Directories: extension that contains multiple CMake projects that cannot be described by one of the above type
-Moreover those project are either directly present in the SOFA sources or need to be fetched because they have their own repository
+Moreover, these projects are either present in the SOFA sources or they need to be fetched (meaning that they have their own external repository).
 
-This page only purpose is to summarize those extensions in tables containing 
-- The name + hyperlink to the extension sources either in the SOFA repo or in its own repo
-- A quick description of what it is
-- Activation directives. 
+This page aims at summarizing those extensions in tables containing:
+- the name + hyperlink to the extension sources either in the SOFA repository or in its own repository
+- a short description
+- activation directives
 
-The activations directives propose two ways of activating those plugins in the build tree:
-1. Through custom CMake flags that [can be added during the cmake call](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-D). All of those plugins can be activated with one or two CMake flags named using their type and name. For example, the plugin SofaPython3 can be activated by activating both flags `SOFA_FETCH_SOFAPYTHON3=ON` and `PLUGIN_SOFAPYTHON3=ON` (because its sources are in a separate repository). If points are present in the name, they are replaced by "_" in the flag.
-2. Through preset that can be [specified during the cmake call](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#introduction)
+The activation directives propose two ways of activating those plugins in the build tree:
+1. Through custom CMake flags that [can be added during the CMake call](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-D). All of those plugins can be activated with one or two CMake flags named using their type and name. For example, the plugin SofaPython3 can be activated by activating both flags `SOFA_FETCH_SOFAPYTHON3=ON` and `PLUGIN_SOFAPYTHON3=ON` (because its sources are in a separate repository).
+2. Through preset that can be [specified during the CMake call](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#introduction)
 

--- a/10_Getting_Started/20_Build/50_Activate_Plugins.md
+++ b/10_Getting_Started/20_Build/50_Activate_Plugins.md
@@ -1,9 +1,9 @@
 # Activable plugins for in-tree compilation
 
 Multiple extensions can be activated when building the project. They fall into three categories:
-1. Applications: extension that offers a new feature outside the SOFA API (e.g. a main for launching SOFA)
-2. Plugins: extension that enriches the SOFA API by adding new components or providing more support for external libraries (e.g. new constitutive laws, alternative GUIs)
-3. Directories: extension that contains multiple CMake projects that cannot be described by one of the above type
+1. Applications: extensions that offer SOFA-based executable applications (e.g. a main for launching SOFA)
+2. Plugins: extensions that enriche the SOFA API by adding new components or providing more support for external libraries (e.g. new constitutive laws, alternative GUIs)
+3. Directories: extensions that contain multiple CMake projects that cannot be described by only one of the above type
 Moreover, these projects are either present in the SOFA sources or they need to be fetched (meaning that they have their own external repository).
 
 This page aims at summarizing those extensions in tables containing:

--- a/35_Plugins/45_Suported_Plugins_List.md
+++ b/35_Plugins/45_Suported_Plugins_List.md
@@ -1,0 +1,8 @@
+# Officially supported plugins
+
+This page purpose is to summarize all the plugins that are officially supported by the SOFA consortium.
+This means that:
+1. We are offering support on those plugins
+2. We include them in our CI process, enforcing their compilation with the master branch
+3. We include them in the distributed binaries 
+

--- a/35_Plugins/45_Suported_Plugins_List.md
+++ b/35_Plugins/45_Suported_Plugins_List.md
@@ -1,8 +1,8 @@
 # Officially supported plugins
 
-This page purpose is to summarize all the plugins that are officially supported by the SOFA consortium.
-This means that:
-1. We are offering support on those plugins
-2. We include them in our CI process, enforcing their compilation with the master branch
-3. We include them in the distributed binaries 
+This page aims at summarizing all plugins that are officially supported by the SOFA consortium.
+This means that the SOFA consortium commits to:
+1. Including them in our continuous integration pipeline, thus assessing the compilation at every push in the SOFA master branch, at each new pull-request and at each nightly build
+2. Including them in the official bi-annual SOFA binaries 
+3. Providing technical support on these plugins
 


### PR DESCRIPTION
This PR adds unfinished headers that will be completed later on by the doc generation action using the scripts introduced in this PR: https://github.com/sofa-framework/doc/pull/178 

This PR need to be merge right **after** the 178. 

The goal of this work is to generate two pages in the doc: 
1. For building: a table of all the plugins that can be activated during the build to be built in-tree. this table is generated using the CMakeLists files in applications and the Presets file. 
2. For general purpose: the list of the supported plugins with a description. Again, generated automatically with the preset list.  