### PR TITLE
Clarify how to run SOFA, mention SofaPython3 and the new GLFW-ImGUI

### DIFF
--- a/10_Getting_Started/15_Binaries/10_Binaries_instructions.md
+++ b/10_Getting_Started/15_Binaries/10_Binaries_instructions.md
@@ -1,5 +1,6 @@
 ﻿SOFA provides pre-compiled binaries, eliminating the need to compile the software from its source code. This simplifies the process for users to get started with SOFA. Below are detailed instructions on how to download, install, and execute SOFA:
 
+
 ## Download
 
 To download SOFA, visit the official SOFA website at [https://www.sofa-framework.org/download/](https://www.sofa-framework.org/download/). On this page, you will find the latest version of SOFA. There are two types of files available, download one or the other:
@@ -11,13 +12,22 @@ If you choose the zip file option, extract its contents to access the SOFA appli
 
 If you require a specific version of SOFA, you can also find previous releases on the official SOFA GitHub repository at [https://github.com/sofa-framework/sofa/releases](https://github.com/sofa-framework/sofa/releases).
 
+
 ## Install
 
 If you downloaded an installer file, simply run the file, and follow the installation process as you would for any other software application. This will ensure that SOFA is properly installed on your system.
 
-## Execute
 
+## Run SOFA
+
+### with the SOFA GUI
 To run SOFA, locate and execute the application called `runSofa`. For more detailed information on how to use the application, you can refer to the [page dedicated to runsofa](../../../using-sofa/runsofa/). This documentation will provide you with further guidance on using SOFA effectively.
+
+
+### within a Python environment
+
+Note that the latest SOFA release has been compiled using Python3.12. Make sure to check your Python version before going any further. To use the binary release of SOFA within a Python3 environment, we wrote a section "using Python3" detailing how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
+
 
 ### Notes for macOS Users
 

--- a/10_Getting_Started/15_Binaries/10_Binaries_instructions.md
+++ b/10_Getting_Started/15_Binaries/10_Binaries_instructions.md
@@ -26,7 +26,9 @@ To run SOFA, locate and execute the application called `runSofa`. For more detai
 
 ### within a Python environment
 
-Note that the latest SOFA release has been compiled using Python3.12. Make sure to check your Python version before going any further. To use the binary release of SOFA within a Python3 environment, we wrote a section "using Python3" detailing how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
+To use the binary release of SOFA within a Python3 environment, we wrote a section "using Python3" detailing how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
+
+Note that the latest SOFA release has been compiled using Python3.12. Make sure to check your Python version before going any further. 
 
 
 ### Notes for macOS Users

--- a/10_Getting_Started/15_Binaries/10_Binaries_instructions.md
+++ b/10_Getting_Started/15_Binaries/10_Binaries_instructions.md
@@ -26,7 +26,7 @@ To run SOFA, locate and execute the application called `runSofa`. For more detai
 
 ### within a Python environment
 
-To use the binary release of SOFA within a Python3 environment, we wrote a section "using Python3" detailing how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
+To use the binary release of SOFA within a Python3 environment, the section "using Python3" details how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
 
 Note that the latest SOFA release has been compiled using Python3.12. Make sure to check your Python version before going any further. 
 

--- a/10_Getting_Started/20_Build/10_Linux.md
+++ b/10_Getting_Started/20_Build/10_Linux.md
@@ -290,7 +290,7 @@ To run SOFA, locate and execute the application called `runSofa`. For more detai
 
 ## within a Python environment
 
-To use SOFA within a Python3 environment, we wrote a section "using Python3" detailing how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
+To use SOFA within a Python3 environment, the section "using Python3" details how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
 
 
 

--- a/10_Getting_Started/20_Build/10_Linux.md
+++ b/10_Getting_Started/20_Build/10_Linux.md
@@ -175,7 +175,7 @@ This list does not cover all available SOFA plugins, only the ones that are buil
    ```
 
 
-# Building SOFA
+# Build SOFA
 
 
 ## Setup your source and build directories
@@ -223,7 +223,7 @@ git clone -b master https://github.com/sofa-framework/sofa.git sofa/src
 
 6. Run **Configure**.
 
-7. Fix eventual dependency errors by following CMake messages (see Troubleshooting section below). Do not worry about warnings.
+7. Fix eventual dependency errors by following CMake messages (see Troubleshoot section below). Do not worry about warnings.
 
 8. (optional) Customize SOFA via CMake variables
 
@@ -250,7 +250,7 @@ Time for a coffee!
 
 
 
-## Troubleshooting CMake errors
+## Troubleshoot CMake errors
 
 ### Qt detection error
 To solve Qt detection errors, click on **Add Entry** and add
@@ -279,6 +279,19 @@ COPY\_ONLY with COPYONLY and **Configure** again.
 ## Compilation tutorial
 
 See our page presenting [video tutorial for compilation on Linux](../../video-tutorials/how-to-compile-sofa/#linux).
+
+
+
+# Run SOFA
+
+## with the SOFA GUI
+To run SOFA, locate and execute the application called `runSofa`. For more detailed information on how to use the application, you can refer to the [page dedicated to runsofa](../../../using-sofa/runsofa/). This documentation will provide you with further guidance on using SOFA effectively.
+
+
+## within a Python environment
+
+To use SOFA within a Python3 environment, we wrote a section "using Python3" detailing how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
+
 
 
 

--- a/10_Getting_Started/20_Build/20_MacOS.md
+++ b/10_Getting_Started/20_Build/20_MacOS.md
@@ -141,7 +141,7 @@ This list does not cover all available SOFA plugins, only the ones that are buil
    ```
 
 
-# Building SOFA
+# Build SOFA
 
 
 ## Setup your source and build directories
@@ -184,7 +184,7 @@ git clone -b master https://github.com/sofa-framework/sofa.git sofa/src
 
 4. Keep "Use default native compilers" and press "Done".
 
-5. Fix eventual dependency errors by following CMake messages (see Troubleshooting section below). Do not worry about warnings.
+5. Fix eventual dependency errors by following CMake messages (see Troubleshoot section below). Do not worry about warnings.
 
 6. Customize SOFA via CMake variables
 
@@ -207,7 +207,7 @@ Time for a coffee!
 
 
 
-## Troubleshooting CMake errors
+## Troubleshoot CMake errors
 
 ### Qt detection error
 To solve Qt detection errors, click on **Add Entry** and add
@@ -229,3 +229,16 @@ A further dev warning may appear:
 This is just a typo with Qt5CoreMacros.cmake file. It uses COPY\_ONLY
 instead of COPYONLY. Simply edit your Qt5CoreMacros.cmake, replace
 COPY\_ONLY with COPYONLY and **Configure** again.
+
+
+# Run SOFA
+
+## with the SOFA GUI
+To run SOFA, locate and execute the application called `runSofa`. For more detailed information on how to use the application, you can refer to the [page dedicated to runsofa](../../../using-sofa/runsofa/). This documentation will provide you with further guidance on using SOFA effectively.
+
+
+## within a Python environment
+
+To use SOFA within a Python3 environment, we wrote a section "using Python3" detailing how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
+
+

--- a/10_Getting_Started/20_Build/20_MacOS.md
+++ b/10_Getting_Started/20_Build/20_MacOS.md
@@ -239,6 +239,6 @@ To run SOFA, locate and execute the application called `runSofa`. For more detai
 
 ## within a Python environment
 
-To use SOFA within a Python3 environment, we wrote a section "using Python3" detailing how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
+To use SOFA within a Python3 environment, the section "using Python3" details how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
 
 

--- a/10_Getting_Started/20_Build/30_Windows.md
+++ b/10_Getting_Started/20_Build/30_Windows.md
@@ -227,6 +227,6 @@ To run SOFA, locate and execute the application called `runSofa`. For more detai
 
 ## within a Python environment
 
-To use SOFA within a Python3 environment, we wrote a section "using Python3" detailing how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
+To use SOFA within a Python3 environment, the section "using Python3" details how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
 
 

--- a/10_Getting_Started/20_Build/30_Windows.md
+++ b/10_Getting_Started/20_Build/30_Windows.md
@@ -87,7 +87,7 @@ You can add Boost and Qt to your PATH to ease their detection by CMake.
 **Qt**: add `your/Qt/path/msvcXXXX_XX/bin` and `your/Qt/path/msvcXXXX_XX/lib`
 
 
-# Building SOFA
+# Build SOFA
 
 
 ## Setup your source and build directories
@@ -143,7 +143,7 @@ git clone -b master https://github.com/sofa-framework/sofa.git sofa/src
    - If you want to use **another IDE like QtCreator**, select "CodeBlocks - Ninja" (recommended, needs [Ninja](#optional-ninja-build-system)) or "CodeBlocks - NMake".
    Keep "Use default native compilers" and press "Finish".
 
-7. Fix eventual dependency errors by following CMake messages (see Troubleshooting section below). Do not worry about warnings.
+7. Fix eventual dependency errors by following CMake messages (see Troubleshoot section below). Do not worry about warnings.
 
    - e.g. define the `Eigen3_DIR` with the path where you installed Eigen
 
@@ -175,7 +175,7 @@ Example with Ninja:
 Time for a coffee!
 
 
-## Troubleshooting CMake errors
+## Troubleshoot CMake errors
 
 ### Qt detection error
 To solve Qt detection errors, click on **Add Entry** and add
@@ -216,3 +216,17 @@ The two scripts `setup-windows_1.bat` and `setup-windows_2.bat` install the mini
 ## Compilation tutorial
 
 See our page presenting [video tutorial for compilation on Windows](../../video-tutorials/how-to-compile-sofa/#windows).
+
+
+
+# Run SOFA
+
+## with the SOFA GUI
+To run SOFA, locate and execute the application called `runSofa`. For more detailed information on how to use the application, you can refer to the [page dedicated to runsofa](../../../using-sofa/runsofa/). This documentation will provide you with further guidance on using SOFA effectively.
+
+
+## within a Python environment
+
+To use SOFA within a Python3 environment, we wrote a section "using Python3" detailing how to [set up your environment on various operating systems](https://sofapython3.readthedocs.io/en/latest/content/Installation.html#using-python3).
+
+

--- a/15_Using_SOFA/10_runSofa.md
+++ b/15_Using_SOFA/10_runSofa.md
@@ -1,11 +1,9 @@
-### runSOFA
-
 The default compilation of SOFA produces a binary file called **runSofa**, which can be
 found in the folder *%{SOFA\_BUILD\_DIR}/bin*.
-The execution of the binary - either via the terminal or by double-clicking the executable -
-launches a default [XML scene](./../create-your-scene-in-xml) with the name caduceus.scn, using the Qt library.
+The execution of the binary (either via the terminal or by double-clicking the executable) launches a default simulation with the default GUI (using the [SofaGLFW plugin](https://github.com/sofa-framework/SofaGLFW/) since v25.06)
+
 ![Execution of runSofa using the
-default scene caduceus](https://www.sofa-framework.org/wp-content/uploads/2014/11/Screenshot-from-2015-01-14-1839152.png)
+default scene in SofaGLFW-ImGUI](https://www.sofa-framework.org/wp-content/uploads/2025/06/Screenshot-SofaGLFW.png)
 
 ### Launch runSOFA
 
@@ -48,9 +46,8 @@ If using the shipped binaries of SOFA (or the default CMake options when compili
 
 ### Load and run a specific scene
 
-The default scene loaded by **runSofa** is named “caduceus.scn”. This
-scene file can be found in *%{SOFA\_SOURCE\_DIR}/examples/Demos*, along
-with other demo scenes. Let us see now how to load one of these scenes:
+The default scene loaded by **runSofa** is named SofaScene.scn”. This [XML scene](./../create-your-scene-in-xml) file can be found in *%{SOFA\_SOURCE\_DIR}/examples/Demos*, along with other demo scenes.
+Let us see now how to load one of these scenes:
 
 -   From the **runSofa** interface, you can select a scene file through
     the “File-&gt;Open” Menu (Ctrl+O), and run it by simply pressing the
@@ -59,3 +56,8 @@ with other demo scenes. Let us see now how to load one of these scenes:
     specify the scene file to load as an argument.
 
 
+### Open a Python script
+
+To open a Python script with runSofa, you need to make sure the SofaPython3 plugin is available. To do so, you can click on `Edit > PluginManager` and browse the plugin list. If the plugin SofaPython3 is not present, make sure to add the associated dynamic library using the button `Add`.
+
+More about SOFA & Python can be found on the [SofaPython3 documentation](https://sofapython3.readthedocs.io/en/latest).

--- a/15_Using_SOFA/10_runSofa.md
+++ b/15_Using_SOFA/10_runSofa.md
@@ -46,7 +46,7 @@ If using the shipped binaries of SOFA (or the default CMake options when compili
 
 ### Load and run a specific scene
 
-The default scene loaded by **runSofa** is named SofaScene.scn”. This [XML scene](./../create-your-scene-in-xml) file can be found in *%{SOFA\_SOURCE\_DIR}/examples/Demos*, along with other demo scenes.
+The default scene loaded by **runSofa** is named "*fallingSOFA.scn*". This [XML scene](./../create-your-scene-in-xml) file can be found in *%{SOFA\_SOURCE\_DIR}/examples/Demos*, along with other demo scenes.
 Let us see now how to load one of these scenes:
 
 -   From the **runSofa** interface, you can select a scene file through


### PR DESCRIPTION
Further to user discussions, the link between compilation and actually running SOFA was missing
I added it and tried to explicit the use of SOFA with Python and within a Python environment.

Finally, I added the mention of the new default default GUI based on [SofaGLFW-ImGui](https://github.com/sofa-framework/SofaGLFW/) --> see #194