### PR TITLE
Drop polyfill as it is a potential threat

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -65,5 +65,4 @@ markdown_extensions:
  
 extra_javascript:
   - javascripts/config.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
Lately when connecting to the doc, a polyfill registraiton pop-up is showed. I don't like it. 

This dependency was there for compatibility with very old browser. But it is outdated. Plus polyfill is know to be a huge security breach. So let's drop it entirely.